### PR TITLE
task_3_5: contexts, try to rename

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,24 +1,23 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
-class MyApp extends StatelessWidget {
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      ),
-      home: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          MyFirstWidget(),
-          const MyFirstStatefulWidget()
-        ],
+      title: 'First app',
+      home: new Scaffold(
+        backgroundColor: Colors.white,
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            MyFirstWidget(),
+            MyFirstStatefulWidget()
+          ],
+        ),
       )
     );
   }
@@ -47,6 +46,11 @@ class MySmallText extends StatelessWidget {
 class MyFirstWidget extends StatelessWidget {
   int count = 0;
 
+  // Контекста нету в полях класса StatelessWidget, ошибка компиляции
+  // getContextRuntimeType() {
+  //   return context.runtimeType;
+  // }
+
   @override
   Widget build(BuildContext context) {
     count += 1;
@@ -71,8 +75,14 @@ class MyFirstStatefulWidget extends StatefulWidget {
 class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
   int count = 0;
 
+  getContextRuntimeType() {
+    return context.runtimeType;
+  }
+
   @override
   Widget build(BuildContext context) {
+    print(getContextRuntimeType());
+
     count += 1;
     print('Statefull counter is $count and it always grow up!');
     return Container(


### PR DESCRIPTION
При переименовании файла приложение перестает запускаться из консоли, ругается на Target file "lib/main.dart" not found.
Хотя из студии, если указать в её конфиге Dart entrypoint новый файл - все запустится хорошо. Полагаю что можно найти где-нибудь в кишках фреймворка место, где прописано какой файл запускать, и изменить его. Или задать при запуске flutter run -t lib/start.dart и все заведется. Но лучше, конечно, не надо так.

Андроид как-то очень плохо себя ведет в эмуляторе... Думал на черном фоне не видно title приложения. Но и на светлом тоже не видно, хз где этот title. И ваще андроид как-то с артефактами работает...
<img width="512" alt="Снимок экрана 2020-12-02 в 21 32 07" src="https://user-images.githubusercontent.com/903258/100923384-c315af00-34e7-11eb-9ec3-84857b48c231.png">
<img width="1029" alt="Снимок экрана 2020-12-02 в 21 39 57" src="https://user-images.githubusercontent.com/903258/100923396-c872f980-34e7-11eb-8488-7f502f1b8a7b.png">

Чтение документации показало, что title будет отображаться в recent apps. Ну, может это Pixel4 просто такой телефон, что ничего похожего не показывает в recent apps..
<img width="1651" alt="Снимок экрана 2020-12-02 в 21 49 31" src="https://user-images.githubusercontent.com/903258/100923803-69fa4b00-34e8-11eb-869a-2b57e493611a.png">


Контекст как поле класса есть у StatefulWidget, но нету у StatelessWidget, из-за этого метод, который обращается к context в StatelessWidget просто не дает скомпилироваться приложению. 